### PR TITLE
Update de.yaml

### DIFF
--- a/de.yaml
+++ b/de.yaml
@@ -1234,6 +1234,9 @@ MTK:
 MTL:
   title: "Muldentalkreis"
   state: "Sachsen"
+MUC:
+  title: "München"
+  state: "Bayern"
 MVL:
   title: "Landesreg. Mecklenburg-Vorpommern"
   state: "Mecklenburg-Vorpommern"


### PR DESCRIPTION
MUC hinzugefügt:
https://www.muenchen.de/verkehr/aktuell/muc-kennzeichen-fuer-muenchner-fahrzeuge-ab-dezember-2023